### PR TITLE
🔧(feat): add filter to isolate job executor between Blue and Green en…

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
@@ -211,6 +211,10 @@
         )
       </if>
 
+      <if test="parameter.tenantId != null or parameter.tenantId != empty">
+          and RES.TENANT_ID_ = #{parameter.tenantId}
+      </if>
+
       <if test="parameter.jobPriorityMin != null">
         and RES.PRIORITY_ &gt;= #{parameter.jobPriorityMin}
       </if>


### PR DESCRIPTION
…vironments

- Implemented a filter to ensure that the job executor of one environment does not retrieve jobs from the other.  
- When the Blue environment is active, the job executor ignores jobs from the Green environment.  
- When the Green environment is active, the job executor ignores jobs from the Blue environment.  
- Used `tenantId` as a unique identifier to validate and enforce the restriction.